### PR TITLE
[fix] 홈 화면 캐시 및 동행모집글 바로가기 구현

### DIFF
--- a/core/data/src/main/kotlin/com/tripmate/android/core/data/repository/MateRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/tripmate/android/core/data/repository/MateRepositoryImpl.kt
@@ -27,7 +27,7 @@ internal class MateRepositoryImpl @Inject constructor(
         personalizationDataSource.completePersonalization(flag)
     }
 
-    override suspend fun getCompanionsDetailInfo(companionId: Int): Result<MateRecruitPostEntity> = runSuspendCatching {
+    override suspend fun getCompanionsDetailInfo(companionId: Long): Result<MateRecruitPostEntity> = runSuspendCatching {
         val response = service.getCompanionsDetailInfo(companionId).data
 
         MateRecruitPostEntity(
@@ -69,8 +69,8 @@ internal class MateRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun companionApply(companionId: Int): Result<Unit> = runSuspendCatching {
-        service.companionsApply(CompanionApplyRequest(companionId.toLong(), tokenDataSource.getId()))
+    override suspend fun companionApply(companionId: Long): Result<Unit> = runSuspendCatching {
+        service.companionsApply(CompanionApplyRequest(companionId, tokenDataSource.getId()))
     }
 
     override suspend fun createCompanionRecruitment(mateRecruitmentEntity: MateRecruitmentEntity) = runSuspendCatching {

--- a/core/data/src/main/kotlin/com/tripmate/android/core/data/repository/TripDetailRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/tripmate/android/core/data/repository/TripDetailRepositoryImpl.kt
@@ -45,7 +45,7 @@ internal class TripDetailRepositoryImpl @Inject constructor(
             },
             tripDetailMateRecruit = arrayListOf<TripDetailMateRecruitEntity>().apply {
                 tripDetailInfo.companionRecruits.forEach { item ->
-                    if (item.companionId != userId.toInt()) {
+                    if (item.companionId != userId) {
                         this.add(
                             TripDetailMateRecruitEntity(
                                 companionId = item.companionId,

--- a/core/domain/src/main/kotlin/com/tripmate/android/domain/entity/TripDetailMateRecruitEntity.kt
+++ b/core/domain/src/main/kotlin/com/tripmate/android/domain/entity/TripDetailMateRecruitEntity.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Stable
 
 @Stable
 data class TripDetailMateRecruitEntity(
-    val companionId: Int = 0,
+    val companionId: Long = 0,
     val imageResId: Int = 0,
     val profileImage: String = "",
     val mateName: String = "",

--- a/core/domain/src/main/kotlin/com/tripmate/android/domain/repository/MateRepository.kt
+++ b/core/domain/src/main/kotlin/com/tripmate/android/domain/repository/MateRepository.kt
@@ -6,7 +6,7 @@ import com.tripmate.android.domain.entity.MateRecruitmentEntity
 interface MateRepository {
     suspend fun checkPersonalizationCompletion(): Boolean
     suspend fun completePersonalization(flag: Boolean)
-    suspend fun companionApply(companionId: Int): Result<Unit>
-    suspend fun getCompanionsDetailInfo(companionId: Int): Result<MateRecruitPostEntity>
+    suspend fun companionApply(companionId: Long): Result<Unit>
+    suspend fun getCompanionsDetailInfo(companionId: Long): Result<MateRecruitPostEntity>
     suspend fun createCompanionRecruitment(mateRecruitmentEntity: MateRecruitmentEntity): Result<Unit>
 }

--- a/core/network/src/main/kotlin/com/tripmate/android/core/network/response/TripDetailInfoResponse.kt
+++ b/core/network/src/main/kotlin/com/tripmate/android/core/network/response/TripDetailInfoResponse.kt
@@ -58,7 +58,7 @@ data class RecommendedStyle(
 @Serializable
 data class CompanionRecruit(
     @SerialName("companionId")
-    val companionId: Int,
+    val companionId: Long,
     @SerialName("hostInfo")
     val hostInfo: TripDetailHostInfo,
     @SerialName("title")

--- a/core/network/src/main/kotlin/com/tripmate/android/core/network/service/TripmateService.kt
+++ b/core/network/src/main/kotlin/com/tripmate/android/core/network/service/TripmateService.kt
@@ -46,7 +46,7 @@ interface TripmateService {
 
     @GET("api/v1/companions/user/{companionId}")
     suspend fun getCompanionsDetailInfo(
-        @Path("companionId") companionId: Int,
+        @Path("companionId") companionId: Long,
     ): CompanionDetailInfoResponse
 
     @POST("api/v1/companions/apply")

--- a/feature/home/src/main/kotlin/com/tripmate/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/tripmate/android/feature/home/HomeScreen.kt
@@ -3,6 +3,7 @@ package com.tripmate.android.feature.home
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -172,36 +173,38 @@ private fun ContentForTab(
                 }
             }
         } else {
-            LazyColumn(
-                modifier = Modifier.padding(horizontal = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(40.dp),
-                contentPadding = PaddingValues(bottom = 40.dp),
-            ) {
-                items(uiState.spotList.size) { index ->
-                    val spot = uiState.spotList[index]
-                    val locationTag = spot.address.split(" ").getOrNull(1) ?: ""
-                    val mateTag = if (spot.companionYn) {
-                        if (tabIndex == 0) "액티비티 동행" else "힐링 동행"
-                    } else null // 동행모집이 없으면 mateTag는 null
+            Box {
+                LazyColumn(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(40.dp),
+                    contentPadding = PaddingValues(bottom = 40.dp),
+                ) {
+                    items(uiState.spotList.size) { index ->
+                        val spot = uiState.spotList[index]
+                        val locationTag = spot.address.split(" ").getOrNull(1) ?: ""
+                        val mateTag = if (spot.companionYn) {
+                            if (tabIndex == 0) "액티비티 동행" else "힐링 동행"
+                        } else null // 동행모집이 없으면 mateTag는 null
 
-                    HomeItem(
-                        locationTag = locationTag,
-                        categoryTag = spot.category.smallCategory,
-                        mateTag = mateTag, // mateTag가 null일 경우 표시되지 않음
-                        imgUrl = spot.thumbnailUrl,
-                        title = spot.title,
-                        description = spot.description,
-                        location = spot.address,
-                        modifier = Modifier.clickable {
-                            navigateToTripDetail(spot.id.toString())
-                        },
-                    )
+                        HomeItem(
+                            locationTag = locationTag,
+                            categoryTag = spot.category.smallCategory,
+                            mateTag = mateTag, // mateTag가 null일 경우 표시되지 않음
+                            imgUrl = spot.thumbnailUrl,
+                            title = spot.title,
+                            description = spot.description,
+                            location = spot.address,
+                            modifier = Modifier.clickable {
+                                navigateToTripDetail(spot.id.toString())
+                            },
+                        )
+                    }
                 }
+                LoadingIndicator(
+                    isLoading = uiState.isLoading,
+                    modifier = Modifier.fillMaxSize(),
+                )
             }
-            LoadingIndicator(
-                isLoading = uiState.isLoading,
-                modifier = Modifier.fillMaxSize(),
-            )
         }
     }
 }

--- a/feature/home/src/main/kotlin/com/tripmate/android/feature/home/viewmodel/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/tripmate/android/feature/home/viewmodel/HomeUiState.kt
@@ -13,6 +13,7 @@ data class HomeUiState(
     val spotList: ImmutableList<SpotEntity> = persistentListOf(),
     val spotTypeList: ImmutableList<String> = persistentListOf(),
     val showTripOriginal: Boolean = false,
+    val spotCache: Map<Pair<String, String>, ImmutableList<SpotEntity>> = emptyMap(),
     val tripOriginalList: ImmutableList<TripOriginalData> = persistentListOf(
         TripOriginalData(
             imgUrl = com.tripmate.android.core.designsystem.R.drawable.img_trip1,

--- a/feature/home/src/main/kotlin/com/tripmate/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/tripmate/android/feature/home/viewmodel/HomeViewModel.kt
@@ -1,9 +1,7 @@
 package com.tripmate.android.feature.home.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.tripmate.android.core.common.handleException
 import com.tripmate.android.domain.repository.MapRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf

--- a/feature/home/src/main/kotlin/com/tripmate/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/tripmate/android/feature/home/viewmodel/HomeViewModel.kt
@@ -1,7 +1,9 @@
 package com.tripmate.android.feature.home.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.tripmate.android.core.common.handleException
 import com.tripmate.android.domain.repository.MapRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
@@ -76,28 +78,42 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun getNearbyTouristSpots(spotTypeGroup: String, spotType: String) {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
-            mapRepository.getNearbyTouristSpots(
-                searchType = "RANDOM",
-                latitude = "37.751853",
-                longitude = "128.8760574",
-                range = "10000",
-                spotTypeGroup = spotTypeGroup,
-                spotType = spotType,
-            ).onSuccess { spots ->
-                _uiState.update {
-                    it.copy(
-                        spotList = spots.toImmutableList(),
-                        spotTypeList = spots.map { spotItem ->
-                            getCategoryTag(spotItem.spotType)
-                        }.toImmutableList(),
-                    )
-                }
-            }.onFailure {
-                // 실패 처리 로직
-            }
-            _uiState.update { it.copy(isLoading = false) }
+        val cacheKey = spotTypeGroup to spotType
+        val cachedSpots = _uiState.value.spotCache[cacheKey]
+        if (cachedSpots != null) {
+            _uiState.update {
+                it.copy(
+                    spotList = cachedSpots,
+                    spotTypeList = cachedSpots.map { spotItem ->
+                        getCategoryTag(spotItem.spotType)
+                    }.toImmutableList(),
+                )
+            } // 캐시된 스팟이 있으면 캐시된 스팟으로 업데이트
+        } else {
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true) }
+                mapRepository.getNearbyTouristSpots(
+                    searchType = "RANDOM",
+                    latitude = "37.751853",
+                    longitude = "128.8760574",
+                    range = "10000",
+                    spotTypeGroup = spotTypeGroup,
+                    spotType = spotType,
+                ).onSuccess { spots ->
+                    val immutableSpots = spots.toImmutableList()
+                    _uiState.update { state ->
+                        val newCache = state.spotCache + (cacheKey to immutableSpots)
+                        state.copy(
+                            spotList = immutableSpots,
+                            spotTypeList = immutableSpots.map { spotItem ->
+                                getCategoryTag(spotItem.spotType)
+                            }.toImmutableList(),
+                            spotCache = newCache,
+                        )
+                    }
+                }.onFailure { }
+                _uiState.update { it.copy(isLoading = false) }
+            } // 캐시된 스팟이 없으면 서버에서 가져와서 업데이트
         }
     }
 

--- a/feature/main/src/main/kotlin/com/tripmate/android/feature/main/MainNavController.kt
+++ b/feature/main/src/main/kotlin/com/tripmate/android/feature/main/MainNavController.kt
@@ -25,6 +25,7 @@ import com.tripmate.android.feature.trip_list.navigation.navigateToMateOpenChat
 import com.tripmate.android.feature.trip_list.navigation.navigateToTripList
 import com.tripmate.android.mate.navigation.navigateToMate
 import com.tripmate.android.feature.trip_detail.navigation.navigateToReport
+import com.tripmate.android.feature.trip_list.navigation.navigateToCharacter
 import com.tripmate.android.mate_review.navigation.navigateToMateReview
 
 internal class MainNavController(
@@ -108,6 +109,10 @@ internal class MainNavController(
             tripStyle = tripStyle,
             characterId = characterId,
         )
+    }
+
+    fun navigateToCharacterDescription(characterId: String, tag1: String, tag2: String, tag3: String) {
+        navController.navigateToCharacter(characterId, tag1, tag2, tag3)
     }
 
     fun navigateToReport() {

--- a/feature/main/src/main/kotlin/com/tripmate/android/feature/main/MainNavController.kt
+++ b/feature/main/src/main/kotlin/com/tripmate/android/feature/main/MainNavController.kt
@@ -62,8 +62,8 @@ internal class MainNavController(
         navController.navigateToMateRecruit(spotId, spotTitle, spotAddress)
     }
 
-    fun navigateToMateReview() {
-        navController.navigateToMateReview()
+    fun navigateToMateReview(companionId: Int, title: String, date: String) {
+        navController.navigateToMateReview(companionId, title, date)
     }
 
     fun navigateToTripDetail(spotId: String) {
@@ -86,11 +86,12 @@ internal class MainNavController(
         navController.navigateToWithdraw()
     }
 
-    fun navigateToMateList(companionId: Long, page: Int) {
+    fun navigateToMateList(companionId: Int, page: Int) {
         navController.navigateToMateList(companionId, page)
     }
 
     fun navigateToMateOpenChat(
+        companionId: Int,
         openChatLink: String,
         selectedKeyword1: String,
         selectedKeyword2: String,
@@ -99,6 +100,7 @@ internal class MainNavController(
         characterId: String,
     ) {
         navController.navigateToMateOpenChat(
+            companionId = companionId,
             openChatLink = openChatLink,
             selectedKeyword1 = selectedKeyword1,
             selectedKeyword2 = selectedKeyword2,

--- a/feature/main/src/main/kotlin/com/tripmate/android/feature/main/MainNavController.kt
+++ b/feature/main/src/main/kotlin/com/tripmate/android/feature/main/MainNavController.kt
@@ -62,7 +62,7 @@ internal class MainNavController(
         navController.navigateToMateRecruit(spotId, spotTitle, spotAddress)
     }
 
-    fun navigateToMateReview(companionId: Int, title: String, date: String) {
+    fun navigateToMateReview(companionId: Long, title: String, date: String) {
         navController.navigateToMateReview(companionId, title, date)
     }
 
@@ -70,7 +70,7 @@ internal class MainNavController(
         navController.navigateToTripDetail(spotId)
     }
 
-    fun navigateToMateReviewPost(companionId: Int) {
+    fun navigateToMateReviewPost(companionId: Long) {
         navController.navigateToMateRecruitPost(companionId)
     }
 
@@ -86,12 +86,12 @@ internal class MainNavController(
         navController.navigateToWithdraw()
     }
 
-    fun navigateToMateList(companionId: Int, page: Int) {
+    fun navigateToMateList(companionId: Long, page: Int) {
         navController.navigateToMateList(companionId, page)
     }
 
     fun navigateToMateOpenChat(
-        companionId: Int,
+        companionId: Long,
         openChatLink: String,
         selectedKeyword1: String,
         selectedKeyword2: String,

--- a/feature/main/src/main/kotlin/com/tripmate/android/feature/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/tripmate/android/feature/main/MainScreen.kt
@@ -58,6 +58,7 @@ import com.tripmate.android.feature.trip_list.navigation.mateOpenChatNavGraph
 import com.tripmate.android.feature.trip_list.navigation.tripListNavGraph
 import com.tripmate.android.mate.navigation.mateNavGraph
 import com.tripmate.android.feature.trip_detail.navigation.reportNavGraph
+import com.tripmate.android.feature.trip_list.navigation.characterNavGraph
 import com.tripmate.android.mate_review.navigation.mateReviewNavGraph
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -139,6 +140,7 @@ internal fun MainScreen(
             mateListNavGraph(
                 padding = innerPadding,
                 popBackStack = navController::popBackStackIfNotHome,
+                navigateToCharacterDescription = navController::navigateToCharacterDescription,
             )
             mateOpenChatNavGraph(
                 popBackStack = navController::popBackStackIfNotHome,
@@ -165,6 +167,9 @@ internal fun MainScreen(
                 popBackStack = navController::popBackStackIfNotHome,
             )
             tripOriginalNavGraph(
+                padding = innerPadding,
+            )
+            characterNavGraph(
                 padding = innerPadding,
             )
         }

--- a/feature/main/src/main/kotlin/com/tripmate/android/feature/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/tripmate/android/feature/main/MainScreen.kt
@@ -142,6 +142,7 @@ internal fun MainScreen(
             )
             mateOpenChatNavGraph(
                 popBackStack = navController::popBackStackIfNotHome,
+                navigateToDetailScreen = navController::navigateToMateReviewPost,
             )
             myPickNavGraph(
                 padding = innerPadding,

--- a/feature/mate-recruit-post/src/main/kotlin/com/tripmate/android/feature/mate_recruit_post/navigation/MateRecruitPostNavigation.kt
+++ b/feature/mate-recruit-post/src/main/kotlin/com/tripmate/android/feature/mate_recruit_post/navigation/MateRecruitPostNavigation.kt
@@ -11,7 +11,7 @@ import com.tripmate.android.feature.mate_recruit_post.MateRecruitPostRoute
 const val COMPANION_ID = "companion_dd"
 const val MATE_RECRUIT_POST_ROUTE = "mate_recruit_post_route/{$COMPANION_ID}"
 
-fun NavController.navigateToMateRecruitPost(companionId: Int) {
+fun NavController.navigateToMateRecruitPost(companionId: Long) {
     navigate("mate_recruit_post_route/$companionId")
 }
 

--- a/feature/mate-recruit-post/src/main/kotlin/com/tripmate/android/feature/mate_recruit_post/viewmodel/MateRecruitPostViewModel.kt
+++ b/feature/mate-recruit-post/src/main/kotlin/com/tripmate/android/feature/mate_recruit_post/viewmodel/MateRecruitPostViewModel.kt
@@ -24,7 +24,7 @@ class MateRecruitPostViewModel @Inject constructor(
     private val mateRepository: MateRepository,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
-    private val companionId: Int = requireNotNull(savedStateHandle.get<Int>(COMPANION_ID))
+    private val companionId: Long = requireNotNull(savedStateHandle.get<Long>(COMPANION_ID))
 
     private val _uiState = MutableStateFlow(MateRecruitPostUiState())
     val uiState: StateFlow<MateRecruitPostUiState> = _uiState.asStateFlow()

--- a/feature/mate-review/src/main/kotlin/com/tripmate/android/mate_review/navigation/MateReviewNavigation.kt
+++ b/feature/mate-review/src/main/kotlin/com/tripmate/android/mate_review/navigation/MateReviewNavigation.kt
@@ -3,20 +3,38 @@ package com.tripmate.android.mate_review.navigation
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.tripmate.android.mate_review.MateReviewRoute
 
-const val MATE_REVIEW_ROUTE = "mate_review_route"
+const val COMPANION_ID = "companion_id"
+const val TITLE = "title"
+const val DATE = "date"
+const val MATE_REVIEW_ROUTE = "mate_review_route/{$COMPANION_ID}/{$TITLE}/{$DATE}"
 
-fun NavController.navigateToMateReview() {
-    navigate(MATE_REVIEW_ROUTE)
+fun NavController.navigateToMateReview(companionId: Long, title: String, date: String) {
+    navigate("mate_review_route/$companionId/$title/$date")
 }
 
 fun NavGraphBuilder.mateReviewNavGraph(
     padding: PaddingValues,
     popBackStack: () -> Unit,
 ) {
-    composable(route = MATE_REVIEW_ROUTE) {
+    composable(
+        route = MATE_REVIEW_ROUTE,
+        arguments = listOf(
+            navArgument(COMPANION_ID) {
+                type = NavType.LongType
+            },
+            navArgument(TITLE) {
+                type = NavType.StringType
+            },
+            navArgument(DATE) {
+                type = NavType.StringType
+            },
+        ),
+    ) {
         MateReviewRoute(
             innerPadding = padding,
             popBackStack = popBackStack,

--- a/feature/trip-detail/src/main/kotlin/com/tripmate/android/feature/trip_detail/TripDetailScreen.kt
+++ b/feature/trip-detail/src/main/kotlin/com/tripmate/android/feature/trip_detail/TripDetailScreen.kt
@@ -69,7 +69,7 @@ fun TripDetailRoute(
     innerPadding: PaddingValues,
     popBackStack: () -> Unit,
     navigateToMateRecruit: (String, String, String) -> Unit,
-    navigateToMateReviewPost: (Int) -> Unit,
+    navigateToMateReviewPost: (Long) -> Unit,
     navigateToReport: () -> Unit,
     viewModel: TripDetailViewModel = hiltViewModel(),
 ) {

--- a/feature/trip-detail/src/main/kotlin/com/tripmate/android/feature/trip_detail/navigation/TripDetailNavigation.kt
+++ b/feature/trip-detail/src/main/kotlin/com/tripmate/android/feature/trip_detail/navigation/TripDetailNavigation.kt
@@ -19,7 +19,7 @@ fun NavGraphBuilder.tripDetailNavGraph(
     padding: PaddingValues,
     popBackStack: () -> Unit,
     navigateToMateRecruit: (String, String, String) -> Unit,
-    navigateToMateReviewPost: (Int) -> Unit,
+    navigateToMateReviewPost: (Long) -> Unit,
     navigateToReport: () -> Unit,
 ) {
     composable(

--- a/feature/trip-detail/src/main/kotlin/com/tripmate/android/feature/trip_detail/viewmodel/TripDetailUiAction.kt
+++ b/feature/trip-detail/src/main/kotlin/com/tripmate/android/feature/trip_detail/viewmodel/TripDetailUiAction.kt
@@ -5,6 +5,6 @@ sealed interface TripDetailUiAction {
     data class OnTabChanged(val index: Int) : TripDetailUiAction
     data object GetTripDetailInfo : TripDetailUiAction
     data object OnClickMateRecruit : TripDetailUiAction
-    data class OnClickMateReviewPost(val companionId: Int) : TripDetailUiAction
+    data class OnClickMateReviewPost(val companionId: Long) : TripDetailUiAction
     data object OnClickReport : TripDetailUiAction
 }

--- a/feature/trip-detail/src/main/kotlin/com/tripmate/android/feature/trip_detail/viewmodel/TripDetailUiEvent.kt
+++ b/feature/trip-detail/src/main/kotlin/com/tripmate/android/feature/trip_detail/viewmodel/TripDetailUiEvent.kt
@@ -3,6 +3,6 @@ package com.tripmate.android.feature.trip_detail.viewmodel
 sealed interface TripDetailUiEvent {
     data object NavigateBack : TripDetailUiEvent
     data class NavigateMateRecruit(val spotId: String, val spotTitle: String, val spotAddress: String) : TripDetailUiEvent
-    data class NavigateToMateReviewPost(val companionId: Int) : TripDetailUiEvent
+    data class NavigateToMateReviewPost(val companionId: Long) : TripDetailUiEvent
     data object NavigateToReport : TripDetailUiEvent
 }

--- a/feature/trip-detail/src/main/kotlin/com/tripmate/android/feature/trip_detail/viewmodel/TripDetailViewModel.kt
+++ b/feature/trip-detail/src/main/kotlin/com/tripmate/android/feature/trip_detail/viewmodel/TripDetailViewModel.kt
@@ -77,7 +77,7 @@ class TripDetailViewModel @Inject constructor(
         }
     }
 
-    private fun navigateMateReviewPost(companionId: Int) {
+    private fun navigateMateReviewPost(companionId: Long) {
         viewModelScope.launch {
             _uiEvent.send(TripDetailUiEvent.NavigateToMateReviewPost(companionId))
         }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/CharacterScreen.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/CharacterScreen.kt
@@ -63,9 +63,7 @@ internal fun CharacterScreen(
             )
         }
     }
-
 }
-
 
 private fun getCharacterTypeIntro(characterId: String): String {
     return when (characterId) {

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/CharacterScreen.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/CharacterScreen.kt
@@ -1,140 +1,53 @@
 package com.tripmate.android.feature.trip_list
 
-import android.content.Context
-import android.content.Intent
-import android.net.Uri
-import android.util.Patterns
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat.startActivity
-import androidx.hilt.navigation.compose.hiltViewModel
-import com.tripmate.android.core.common.ObserveAsEvents
-import com.tripmate.android.core.designsystem.component.TripmateButton
-import com.tripmate.android.core.designsystem.component.TripmateOutlinedButton
 import com.tripmate.android.core.designsystem.theme.Background02
-import com.tripmate.android.core.designsystem.theme.Medium16_SemiBold
-import com.tripmate.android.core.designsystem.theme.Primary01
-import com.tripmate.android.core.designsystem.theme.TripmateTheme
-import com.tripmate.android.core.ui.DevicePreview
 import com.tripmate.android.feature.trip_list.component.MyTripStyle
-import com.tripmate.android.feature.trip_list.viewmodel.TripListUiAction
-import com.tripmate.android.feature.trip_list.viewmodel.TripListUiEvent
-import com.tripmate.android.feature.trip_list.viewmodel.TripListViewModel
-import com.tripmate.android.feature.triplist.R
-import tech.thdev.compose.exteions.system.ui.controller.rememberExSystemUiController
-import java.net.MalformedURLException
-import java.net.URL
 
 @Composable
-internal fun MateOpenChatRoute(
-    popBackStack: () -> Unit,
-    companionId: Long,
-    openChatLink: String,
-    selectedKeywords: List<String>,
-    tripStyle: String,
+internal fun CharacterRoute(
+    innerPadding: PaddingValues,
     characterId: String,
-    navigateToDetailScreen: (Long) -> Unit,
-    viewModel: TripListViewModel = hiltViewModel(),
+    tag1: String,
+    tag2: String,
+    tag3: String,
 ) {
-    val context = LocalContext.current
-    val systemUiController = rememberExSystemUiController()
-    val isDarkTheme = isSystemInDarkTheme()
-
-    DisposableEffect(systemUiController) {
-        systemUiController.setStatusBarColor(
-            color = Color.Transparent,
-            darkIcons = true,
-        )
-        onDispose {
-            systemUiController.setStatusBarColor(
-                color = Color.White,
-                darkIcons = !isDarkTheme,
-            )
-        }
-    }
-
-    ObserveAsEvents(flow = viewModel.uiEvent) { event ->
-        when (event) {
-            is TripListUiEvent.NavigateBack -> popBackStack()
-            is TripListUiEvent.NavigateToKakaoOpenChat -> {
-                openKakaoOpenChat(context, event.openChatUrl)
-            }
-            is TripListUiEvent.NavigateToDetailScreen -> navigateToDetailScreen(event.companionId)
-            else -> {}
-        }
-    }
-
-    MateOpenChatScreen(
-        companionId = companionId,
-        openChatLink = openChatLink,
-        selectedKeywords = selectedKeywords,
-        tripStyle = tripStyle,
+    CharacterScreen(
+        innerPadding = innerPadding,
         characterId = characterId,
-        onAction = viewModel::onAction,
+        tag1 = tag1,
+        tag2 = tag2,
+        tag3 = tag3,
     )
 }
 
-private fun openKakaoOpenChat(context: Context, url: String) {
-    if (isValidUrl(url)) {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-        startActivity(context, intent, null)
-    }
-}
-
-private fun isValidUrl(urlString: String): Boolean {
-    return try {
-        // 안드로이드의 Patterns 클래스를 사용하여 URL 형식 검사
-        val urlPattern = Patterns.WEB_URL
-        if (!urlPattern.matcher(urlString).matches()) {
-            return false
-        }
-
-        // URL 객체 생성을 통한 추가 검증
-        val url = URL(urlString)
-        val protocol = url.protocol
-        if (protocol != "http" && protocol != "https") {
-            return false
-        }
-        true
-    } catch (e: MalformedURLException) {
-        false
-    }
-}
-
 @Composable
-internal fun MateOpenChatScreen(
-    companionId: Long,
-    openChatLink: String,
-    selectedKeywords: List<String>,
-    tripStyle: String,
+internal fun CharacterScreen(
+    innerPadding: PaddingValues,
     characterId: String,
-    onAction: (TripListUiAction) -> Unit,
-    modifier: Modifier = Modifier,
+    tag1: String,
+    tag2: String,
+    tag3: String,
 ) {
     Box(
-        modifier = modifier
-            .fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Background02)
+            .padding(innerPadding),
     ) {
         Column(
-            modifier = modifier
+            modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
                 .background(Background02),
@@ -144,50 +57,15 @@ internal fun MateOpenChatScreen(
                 characterId = characterId,
                 characterTypeIntro = getCharacterTypeIntro(characterId),
                 tripStyleIntro = getTripStyleIntro(characterId),
-                selectedKeywords = selectedKeywords,
-                isCharacterTripLead = true,
+                selectedKeywords = listOf(tag1, tag2, tag3),
+                isCharacterTripLead = false,
                 modifier = Modifier.fillMaxWidth(),
             )
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                TripmateOutlinedButton(
-                    onClick = {
-                        onAction(TripListUiAction.OnTripDetailClicked(companionId))
-                    },
-                    containerColor = Background02,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(56.dp),
-                ) {
-                    Text(
-                        text = stringResource(R.string.navigate_to_trip_detail),
-                        color = Primary01,
-                        style = Medium16_SemiBold,
-                    )
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-                TripmateButton(
-                    onClick = {
-                        onAction(TripListUiAction.OnMateOpenChatClicked(openChatLink))
-                    },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(56.dp),
-                ) {
-                    Text(
-                        text = stringResource(R.string.navigate_to_mate_open_chat),
-                        style = Medium16_SemiBold,
-                    )
-                }
-                Spacer(modifier = Modifier.height(56.dp))
-            }
         }
     }
+
 }
+
 
 private fun getCharacterTypeIntro(characterId: String): String {
     return when (characterId) {
@@ -230,20 +108,5 @@ private fun getTripStyleIntro(characterId: String): String {
 
         else -> "판다는 특별한 계획 없이 여행을 즐기며, 그때그때의 기분에 따라 움직이곤 해요. 여행 대부분의 시간을 편안한 장소에서 보내곤 해요.\n" +
             "\n자연 속에서 휴식을 취하거나 느긋하게 경치를 감상하기도 한답니다. 새로운 도전보다는 익숙한 환경에서 편안함을 느끼며, 여행의 목적이 휴식과 힐링에 맞춰져 있는 유형이죠."
-    }
-}
-
-@DevicePreview
-@Composable
-private fun MyTripCharacterInfoPreview() {
-    TripmateTheme {
-        MateOpenChatScreen(
-            onAction = {},
-            openChatLink = "https://open.kakao.com/o/gObLOlQg",
-            selectedKeywords = listOf("힐링", "휴식", "자연"),
-            tripStyle = "인스타 인생 맛집",
-            characterId = "HONEYBEE",
-            companionId = 1,
-        )
     }
 }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/MateListScreen.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/MateListScreen.kt
@@ -48,6 +48,7 @@ import com.tripmate.android.feature.triplist.R
 internal fun MateListRoute(
     innerPadding: PaddingValues,
     popBackStack: () -> Unit,
+    navigateToCharacterDescription: (String, String, String, String) -> Unit,
     viewModel: TripListViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -55,6 +56,14 @@ internal fun MateListRoute(
     ObserveAsEvents(flow = viewModel.uiEvent) { event ->
         when (event) {
             is TripListUiEvent.NavigateBack -> popBackStack()
+            is TripListUiEvent.NavigateToCharacterDescription -> {
+                navigateToCharacterDescription(
+                    event.characterId,
+                    event.tag1,
+                    event.tag2,
+                    event.tag3,
+                )
+            }
             else -> { }
         }
     }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/MateOpenChatScreen.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/MateOpenChatScreen.kt
@@ -46,12 +46,12 @@ import java.net.URL
 @Composable
 internal fun MateOpenChatRoute(
     popBackStack: () -> Unit,
-    companionId: Int,
+    companionId: Long,
     openChatLink: String,
     selectedKeywords: List<String>,
     tripStyle: String,
     characterId: String,
-    navigateToDetailScreen: (Int) -> Unit,
+    navigateToDetailScreen: (Long) -> Unit,
     viewModel: TripListViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -121,7 +121,7 @@ private fun isValidUrl(urlString: String): Boolean {
 
 @Composable
 internal fun MateOpenChatScreen(
-    companionId: Int,
+    companionId: Long,
     openChatLink: String,
     selectedKeywords: List<String>,
     tripStyle: String,

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/MateOpenChatScreen.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/MateOpenChatScreen.kt
@@ -119,6 +119,7 @@ private fun isValidUrl(urlString: String): Boolean {
     }
 }
 
+@Suppress("UnusedParameter")
 @Composable
 internal fun MateOpenChatScreen(
     companionId: Long,

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/MateOpenChatScreen.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/MateOpenChatScreen.kt
@@ -28,8 +28,10 @@ import androidx.core.content.ContextCompat.startActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.tripmate.android.core.common.ObserveAsEvents
 import com.tripmate.android.core.designsystem.component.TripmateButton
+import com.tripmate.android.core.designsystem.component.TripmateOutlinedButton
 import com.tripmate.android.core.designsystem.theme.Background02
 import com.tripmate.android.core.designsystem.theme.Medium16_SemiBold
+import com.tripmate.android.core.designsystem.theme.Primary01
 import com.tripmate.android.core.designsystem.theme.TripmateTheme
 import com.tripmate.android.core.ui.DevicePreview
 import com.tripmate.android.feature.trip_list.component.MyTripStyle
@@ -44,10 +46,12 @@ import java.net.URL
 @Composable
 internal fun MateOpenChatRoute(
     popBackStack: () -> Unit,
+    companionId: Int,
     openChatLink: String,
     selectedKeywords: List<String>,
     tripStyle: String,
     characterId: String,
+    navigateToDetailScreen: (Int) -> Unit,
     viewModel: TripListViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -73,11 +77,13 @@ internal fun MateOpenChatRoute(
             is TripListUiEvent.NavigateToKakaoOpenChat -> {
                 openKakaoOpenChat(context, event.openChatUrl)
             }
+            is TripListUiEvent.NavigateToDetailScreen -> navigateToDetailScreen(event.companionId)
             else -> {}
         }
     }
 
     MateOpenChatScreen(
+        companionId = companionId,
         openChatLink = openChatLink,
         selectedKeywords = selectedKeywords,
         tripStyle = tripStyle,
@@ -115,6 +121,7 @@ private fun isValidUrl(urlString: String): Boolean {
 
 @Composable
 internal fun MateOpenChatScreen(
+    companionId: Int,
     openChatLink: String,
     selectedKeywords: List<String>,
     tripStyle: String,
@@ -147,6 +154,22 @@ internal fun MateOpenChatScreen(
                     .padding(horizontal = 16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
+                TripmateOutlinedButton(
+                    onClick = {
+                        onAction(TripListUiAction.OnTripDetailClicked(companionId))
+                    },
+                    containerColor = Background02,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.navigate_to_trip_detail),
+                        color = Primary01,
+                        style = Medium16_SemiBold,
+                    )
+                }
+                Spacer(modifier = Modifier.height(16.dp))
                 TripmateButton(
                     onClick = {
                         onAction(TripListUiAction.OnMateOpenChatClicked(openChatLink))
@@ -220,6 +243,7 @@ private fun MyTripCharacterInfoPreview() {
             selectedKeywords = listOf("힐링", "휴식", "자연"),
             tripStyle = "인스타 인생 맛집",
             characterId = "HONEYBEE",
+            companionId = 1,
         )
     }
 }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/TripListScreen.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/TripListScreen.kt
@@ -65,7 +65,7 @@ internal fun TripListRoute(
     innerPadding: PaddingValues,
     navigateToMateList: (Long, Int) -> Unit,
     navigateToMateOpenChat: (
-        companionId:Long,
+        companionId: Long,
         openChatLink: String,
         selectedKeyword1: String,
         selectedKeyword2: String,

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/TripListScreen.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/TripListScreen.kt
@@ -63,8 +63,9 @@ import kotlinx.coroutines.launch
 @Composable
 internal fun TripListRoute(
     innerPadding: PaddingValues,
-    navigateToMateList: (Long, Int) -> Unit,
+    navigateToMateList: (Int, Int) -> Unit,
     navigateToMateOpenChat: (
+        companionId:Int,
         openChatLink: String,
         selectedKeyword1: String,
         selectedKeyword2: String,
@@ -80,6 +81,7 @@ internal fun TripListRoute(
         when (event) {
             is TripListUiEvent.NavigateToMateList -> navigateToMateList(event.companionId, event.page)
             is TripListUiEvent.NavigateToMateOpenChat -> navigateToMateOpenChat(
+                event.companionId,
                 event.openChatLink,
                 event.selectedKeyword1,
                 event.selectedKeyword2,
@@ -205,6 +207,7 @@ internal fun TripListScreen(
                                                 companion.tripHostInfoEntity.selectedKeyword,
                                                 companion.tripHostInfoEntity.tripStyle,
                                                 companion.tripHostInfoEntity.characterId,
+                                                companion.companionId,
                                             ),
                                         )
                                     },

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/TripListScreen.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/TripListScreen.kt
@@ -63,9 +63,9 @@ import kotlinx.coroutines.launch
 @Composable
 internal fun TripListRoute(
     innerPadding: PaddingValues,
-    navigateToMateList: (Int, Int) -> Unit,
+    navigateToMateList: (Long, Int) -> Unit,
     navigateToMateOpenChat: (
-        companionId:Int,
+        companionId:Long,
         openChatLink: String,
         selectedKeyword1: String,
         selectedKeyword2: String,

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/TripListScreen.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/TripListScreen.kt
@@ -89,7 +89,6 @@ internal fun TripListRoute(
                 event.tripStyle,
                 event.characterId,
             )
-
             else -> {}
         }
     }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/component/MyTripStyle.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/component/MyTripStyle.kt
@@ -42,13 +42,12 @@ import com.tripmate.android.core.designsystem.theme.TripmateTheme
 import com.tripmate.android.core.designsystem.theme.XLarge24_SemiBold
 import com.tripmate.android.feature.triplist.R
 
-@Suppress("UnusedParameter")
 @Composable
 fun MyTripStyle(
+    isCharacterTripLead: Boolean,
     characterId: String,
     characterTypeIntro: String,
     tripStyleIntro: String,
-    tripStyle: String,
     selectedKeywords: List<String>,
     modifier: Modifier = Modifier,
 ) {
@@ -103,7 +102,7 @@ fun MyTripStyle(
     ) {
         Spacer(modifier = Modifier.height(88.dp))
         Text(
-            text = stringResource(R.string.mate_organizer_type),
+            text = if (isCharacterTripLead) stringResource(R.string.mate_organizer_type) else stringResource(R.string.mate_applicant_type),
             style = Medium16_Mid,
             color = Gray001,
         )
@@ -191,8 +190,8 @@ private fun MyTripStylePreview() {
             characterId = "PENGUIN",
             characterTypeIntro = "펭귄 여행가는 눈이 부릅뜬 아기 펭귄이에요. 눈이 부릅뜬 만큼 호기심이 많고, 새로운 것을 배우는 것을 좋아해요. 또한, 눈이 부릅뜬 만큼 민첩하고 빠르게 움직이는 것을 좋아해요.",
             tripStyleIntro = "펭귄 여행가는 눈이 부릅뜬 아기 펭귄이에요. 눈이 부릅뜬 만큼 호기심이 많고, 새로운 것을 배우는 것을 좋아해요. 또한, 눈이 부릅뜬 만큼 민첩하고 빠르게 움직이는 것을 좋아해요.",
-            tripStyle = "인스타 여행 맛집",
             selectedKeywords = listOf("펭귄", "여행", "휴식"),
+            isCharacterTripLead = false,
         )
     }
 }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/component/Ticket.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/component/Ticket.kt
@@ -94,13 +94,23 @@ internal fun Ticket(
                     TicketType(ticket.selectedKeyword[2])
                 }
                 Spacer(modifier = Modifier.height(46.dp))
-//                Row {
-//                    Text(
-//                        text = "캐릭터 설명보기>",
-//                        style = XSmall12_Reg,
-//                        color = Gray003,
-//                    )
-//                }
+                Row {
+                    Text(
+                        text = "캐릭터 설명보기>",
+                        style = XSmall12_Reg,
+                        color = Gray003,
+                        modifier = Modifier.clickable {
+                            onAction(
+                                TripListUiAction.OnCharacterDescriptionClicked(
+                                    ticket.characterId,
+                                    ticket.selectedKeyword[0],
+                                    ticket.selectedKeyword[1],
+                                    ticket.selectedKeyword[2],
+                                ),
+                            )
+                        },
+                    )
+                }
             }
             Spacer(modifier = Modifier.weight(1f))
             Spacer(modifier = Modifier.width(12.dp))

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/navigation/CharacterDescriptionNavigation.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/navigation/CharacterDescriptionNavigation.kt
@@ -1,0 +1,54 @@
+package com.tripmate.android.feature.trip_list.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.tripmate.android.feature.trip_list.CharacterRoute
+
+const val CHARACTER = "character"
+const val TAG1 = "tag1"
+const val TAG2 = "tag2"
+const val TAG3 = "tag3"
+const val CHARACTER_ROUTE = "character_route/{$CHARACTER}/{$TAG1}/{$TAG2}/{$TAG3}"
+
+fun NavController.navigateToCharacter(characterId: String, tag1: String, tag2: String, tag3: String) {
+    navigate("character_route/$characterId/$tag1/$tag2/$tag3")
+}
+
+fun NavGraphBuilder.characterNavGraph(
+    padding: PaddingValues,
+) {
+    composable(
+        route = CHARACTER_ROUTE,
+        arguments = listOf(
+            navArgument(CHARACTER) {
+                type = NavType.StringType
+            },
+            navArgument(TAG1) {
+                type = NavType.StringType
+            },
+            navArgument(TAG2) {
+                type = NavType.StringType
+            },
+            navArgument(TAG3) {
+                type = NavType.StringType
+            },
+        ),
+    ) { backStackEntry ->
+        val characterId = backStackEntry.arguments?.getString(CHARACTER) ?: ""
+        val tag1 = backStackEntry.arguments?.getString(TAG1) ?: ""
+        val tag2 = backStackEntry.arguments?.getString(TAG2) ?: ""
+        val tag3 = backStackEntry.arguments?.getString(TAG3) ?: ""
+
+        CharacterRoute(
+            innerPadding = padding,
+            characterId = characterId,
+            tag1 = tag1,
+            tag2 = tag2,
+            tag3 = tag3,
+        )
+    }
+}

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/navigation/MateListNavigation.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/navigation/MateListNavigation.kt
@@ -22,6 +22,7 @@ fun NavController.navigateToMateList(
 fun NavGraphBuilder.mateListNavGraph(
     padding: PaddingValues,
     popBackStack: () -> Unit,
+    navigateToCharacterDescription: (String, String, String, String) -> Unit,
 ) {
     composable(
         route = MATE_LIST_ROUTE,
@@ -37,6 +38,7 @@ fun NavGraphBuilder.mateListNavGraph(
         MateListRoute(
             innerPadding = padding,
             popBackStack = popBackStack,
+            navigateToCharacterDescription = navigateToCharacterDescription,
         )
     }
 }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/navigation/MateOpenChatNavigation.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/navigation/MateOpenChatNavigation.kt
@@ -18,7 +18,7 @@ const val COMPANION_ID2 = "companionId2"
 const val MATE_OPEN_CHAT_ROUTE = "mate_open_chat_route/{$OPEN_CHAT_LINK}/{$SELECTED_KEYWORD1}/{$SELECTED_KEYWORD2}/{$SELECTED_KEYWORD3}/{$TRIP_STYLE}/{$CHARACTER_ID}/{$COMPANION_ID2}"
 
 fun NavController.navigateToMateOpenChat(
-    companionId: Int,
+    companionId: Long,
     openChatLink: String,
     selectedKeyword1: String,
     selectedKeyword2: String,
@@ -47,7 +47,7 @@ fun NavController.navigateToMateOpenChat(
 }
 
 fun NavGraphBuilder.mateOpenChatNavGraph(
-    navigateToDetailScreen: (Int) -> Unit,
+    navigateToDetailScreen: (Long) -> Unit,
     popBackStack: () -> Unit,
 ) {
     composable(
@@ -59,10 +59,10 @@ fun NavGraphBuilder.mateOpenChatNavGraph(
             navArgument(SELECTED_KEYWORD3) { type = NavType.StringType },
             navArgument(TRIP_STYLE) { type = NavType.StringType },
             navArgument(CHARACTER_ID) { type = NavType.StringType },
-            navArgument(COMPANION_ID2) { type = NavType.IntType },
+            navArgument(COMPANION_ID2) { type = NavType.LongType },
         ),
     ) { backStackEntry ->
-        val companionId = backStackEntry.arguments?.getInt(COMPANION_ID2) ?: 0
+        val companionId = backStackEntry.arguments?.getLong(COMPANION_ID2) ?: 0
         val openChatLink = backStackEntry.arguments?.getString(OPEN_CHAT_LINK)?.let { Uri.decode(it) } ?: ""
         val selectedKeyword1 = backStackEntry.arguments?.getString(SELECTED_KEYWORD1)?.let { Uri.decode(it) } ?: ""
         val selectedKeyword2 = backStackEntry.arguments?.getString(SELECTED_KEYWORD2)?.let { Uri.decode(it) } ?: ""

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/navigation/MateOpenChatNavigation.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/navigation/MateOpenChatNavigation.kt
@@ -14,9 +14,11 @@ const val SELECTED_KEYWORD2 = "selectedKeyword2"
 const val SELECTED_KEYWORD3 = "selectedKeyword3"
 const val TRIP_STYLE = "tripStyle"
 const val CHARACTER_ID = "characterId"
-const val MATE_OPEN_CHAT_ROUTE = "mate_open_chat_route/{$OPEN_CHAT_LINK}/{$SELECTED_KEYWORD1}/{$SELECTED_KEYWORD2}/{$SELECTED_KEYWORD3}/{$TRIP_STYLE}/{$CHARACTER_ID}"
+const val COMPANION_ID2 = "companionId2"
+const val MATE_OPEN_CHAT_ROUTE = "mate_open_chat_route/{$OPEN_CHAT_LINK}/{$SELECTED_KEYWORD1}/{$SELECTED_KEYWORD2}/{$SELECTED_KEYWORD3}/{$TRIP_STYLE}/{$CHARACTER_ID}/{$COMPANION_ID2}"
 
 fun NavController.navigateToMateOpenChat(
+    companionId: Int,
     openChatLink: String,
     selectedKeyword1: String,
     selectedKeyword2: String,
@@ -24,6 +26,7 @@ fun NavController.navigateToMateOpenChat(
     tripStyle: String,
     characterId: String,
 ) {
+    val encodedCompanionId = Uri.encode(companionId.toString())
     val encodedOpenChatLink = Uri.encode(openChatLink)
     val encodedSelectedKeyword1 = Uri.encode(selectedKeyword1)
     val encodedSelectedKeyword2 = Uri.encode(selectedKeyword2)
@@ -37,12 +40,14 @@ fun NavController.navigateToMateOpenChat(
         "$encodedSelectedKeyword2/" +
         "$encodedSelectedKeyword3/" +
         "$encodedTripStyle/" +
-        "$encodedCharacterId"
+        "$encodedCharacterId/" +
+        "$encodedCompanionId"
 
     navigate(route)
 }
 
 fun NavGraphBuilder.mateOpenChatNavGraph(
+    navigateToDetailScreen: (Int) -> Unit,
     popBackStack: () -> Unit,
 ) {
     composable(
@@ -54,8 +59,10 @@ fun NavGraphBuilder.mateOpenChatNavGraph(
             navArgument(SELECTED_KEYWORD3) { type = NavType.StringType },
             navArgument(TRIP_STYLE) { type = NavType.StringType },
             navArgument(CHARACTER_ID) { type = NavType.StringType },
+            navArgument(COMPANION_ID2) { type = NavType.IntType },
         ),
     ) { backStackEntry ->
+        val companionId = backStackEntry.arguments?.getInt(COMPANION_ID2) ?: 0
         val openChatLink = backStackEntry.arguments?.getString(OPEN_CHAT_LINK)?.let { Uri.decode(it) } ?: ""
         val selectedKeyword1 = backStackEntry.arguments?.getString(SELECTED_KEYWORD1)?.let { Uri.decode(it) } ?: ""
         val selectedKeyword2 = backStackEntry.arguments?.getString(SELECTED_KEYWORD2)?.let { Uri.decode(it) } ?: ""
@@ -69,6 +76,8 @@ fun NavGraphBuilder.mateOpenChatNavGraph(
             selectedKeywords = listOf(selectedKeyword1, selectedKeyword2, selectedKeyword3),
             tripStyle = tripStyle,
             characterId = characterId,
+            companionId = companionId,
+            navigateToDetailScreen = navigateToDetailScreen,
         )
     }
 }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/navigation/TripListNavigation.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/navigation/TripListNavigation.kt
@@ -15,9 +15,9 @@ fun NavController.navigateToTripList(navOptions: NavOptions) {
 
 fun NavGraphBuilder.tripListNavGraph(
     padding: PaddingValues,
-    navigateToMateList: (Int, Int) -> Unit,
+    navigateToMateList: (Long, Int) -> Unit,
     navigateToMateOpenChat: (
-        companionId: Int,
+        companionId: Long,
         openChatLink: String,
         selectedKeyword1: String,
         selectedKeyword2: String,
@@ -25,7 +25,6 @@ fun NavGraphBuilder.tripListNavGraph(
         tripStyle: String,
         characterId: String,
     ) -> Unit,
-    navigateToReviewScreen: (Int, String, String) -> Unit,
 ) {
     composable(route = TRIP_LIST_ROUTE) {
         TripListRoute(

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/navigation/TripListNavigation.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/navigation/TripListNavigation.kt
@@ -15,8 +15,9 @@ fun NavController.navigateToTripList(navOptions: NavOptions) {
 
 fun NavGraphBuilder.tripListNavGraph(
     padding: PaddingValues,
-    navigateToMateList: (Long, Int) -> Unit,
+    navigateToMateList: (Int, Int) -> Unit,
     navigateToMateOpenChat: (
+        companionId: Int,
         openChatLink: String,
         selectedKeyword1: String,
         selectedKeyword2: String,
@@ -24,6 +25,7 @@ fun NavGraphBuilder.tripListNavGraph(
         tripStyle: String,
         characterId: String,
     ) -> Unit,
+    navigateToReviewScreen: (Int, String, String) -> Unit,
 ) {
     composable(route = TRIP_LIST_ROUTE) {
         TripListRoute(

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListUiAction.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListUiAction.kt
@@ -4,8 +4,10 @@ sealed interface TripListUiAction {
     data object OnBackClicked : TripListUiAction
     data class OnTabChanged(val index: Int) : TripListUiAction
     data class OnTicketClicked(val ticketId: Int, val userId: Long) : TripListUiAction
-    data class OnClickViewMateList(val companionId: Long, val page: Int) : TripListUiAction
-    data class OnTripStatusCardClicked(val openChatLink: String, val selectedKeyword: List<String>, val tripStyle: String, val characterId: String) : TripListUiAction
+    data class OnClickViewMateList(val companionId: Int, val page: Int) : TripListUiAction
+    data class OnTripStatusCardClicked(val openChatLink: String, val selectedKeyword: List<String>, val tripStyle: String, val characterId: String, val companionId: Int) : TripListUiAction
     data class OnMateOpenChatClicked(val openKakaoChatLink: String) : TripListUiAction
+    data class OnTripDetailClicked(val companionId: Int) : TripListUiAction
     data object OnSelectMateClicked : TripListUiAction
+    data class OnReviewItemClicked(val companionId: Int, val title: String, val date: String) : TripListUiAction
 }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListUiAction.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListUiAction.kt
@@ -5,8 +5,16 @@ sealed interface TripListUiAction {
     data class OnTabChanged(val index: Int) : TripListUiAction
     data class OnTicketClicked(val ticketId: Int, val userId: Long) : TripListUiAction
     data class OnClickViewMateList(val companionId: Long, val page: Int) : TripListUiAction
-    data class OnTripStatusCardClicked(val openChatLink: String, val selectedKeyword: List<String>, val tripStyle: String, val characterId: String, val companionId: Long) : TripListUiAction
+    data class OnTripStatusCardClicked(
+        val openChatLink: String,
+        val selectedKeyword: List<String>,
+        val tripStyle: String,
+        val characterId: String,
+        val companionId: Long,
+    ) : TripListUiAction
+
     data class OnMateOpenChatClicked(val openKakaoChatLink: String) : TripListUiAction
     data class OnTripDetailClicked(val companionId: Long) : TripListUiAction
     data object OnSelectMateClicked : TripListUiAction
+    data class OnCharacterDescriptionClicked(val characterId: String, val tag1: String, val tag2: String, val tag3: String) : TripListUiAction
 }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListUiAction.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListUiAction.kt
@@ -4,10 +4,9 @@ sealed interface TripListUiAction {
     data object OnBackClicked : TripListUiAction
     data class OnTabChanged(val index: Int) : TripListUiAction
     data class OnTicketClicked(val ticketId: Int, val userId: Long) : TripListUiAction
-    data class OnClickViewMateList(val companionId: Int, val page: Int) : TripListUiAction
-    data class OnTripStatusCardClicked(val openChatLink: String, val selectedKeyword: List<String>, val tripStyle: String, val characterId: String, val companionId: Int) : TripListUiAction
+    data class OnClickViewMateList(val companionId: Long, val page: Int) : TripListUiAction
+    data class OnTripStatusCardClicked(val openChatLink: String, val selectedKeyword: List<String>, val tripStyle: String, val characterId: String, val companionId: Long) : TripListUiAction
     data class OnMateOpenChatClicked(val openKakaoChatLink: String) : TripListUiAction
-    data class OnTripDetailClicked(val companionId: Int) : TripListUiAction
+    data class OnTripDetailClicked(val companionId: Long) : TripListUiAction
     data object OnSelectMateClicked : TripListUiAction
-    data class OnReviewItemClicked(val companionId: Int, val title: String, val date: String) : TripListUiAction
 }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListUiEvent.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListUiEvent.kt
@@ -2,9 +2,9 @@ package com.tripmate.android.feature.trip_list.viewmodel
 
 sealed interface TripListUiEvent {
     data object NavigateBack : TripListUiEvent
-    data class NavigateToMateList(val companionId: Int, val page: Int) : TripListUiEvent
+    data class NavigateToMateList(val companionId: Long, val page: Int) : TripListUiEvent
     data class NavigateToMateOpenChat(
-        val companionId: Int,
+        val companionId: Long,
         val openChatLink: String,
         val selectedKeyword1: String,
         val selectedKeyword2: String,
@@ -13,6 +13,6 @@ sealed interface TripListUiEvent {
         val characterId: String,
     ) : TripListUiEvent
     data class NavigateToKakaoOpenChat(val openChatUrl: String) : TripListUiEvent
-    data class NavigateToReviewScreen(val companionId: Int, val title: String, val date: String) : TripListUiEvent
-    data class NavigateToDetailScreen(val companionId: Int) : TripListUiEvent
+    data class NavigateToReviewScreen(val companionId: Long, val title: String, val date: String) : TripListUiEvent
+    data class NavigateToDetailScreen(val companionId: Long) : TripListUiEvent
 }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListUiEvent.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListUiEvent.kt
@@ -2,8 +2,9 @@ package com.tripmate.android.feature.trip_list.viewmodel
 
 sealed interface TripListUiEvent {
     data object NavigateBack : TripListUiEvent
-    data class NavigateToMateList(val companionId: Long, val page: Int) : TripListUiEvent
+    data class NavigateToMateList(val companionId: Int, val page: Int) : TripListUiEvent
     data class NavigateToMateOpenChat(
+        val companionId: Int,
         val openChatLink: String,
         val selectedKeyword1: String,
         val selectedKeyword2: String,
@@ -12,4 +13,6 @@ sealed interface TripListUiEvent {
         val characterId: String,
     ) : TripListUiEvent
     data class NavigateToKakaoOpenChat(val openChatUrl: String) : TripListUiEvent
+    data class NavigateToReviewScreen(val companionId: Int, val title: String, val date: String) : TripListUiEvent
+    data class NavigateToDetailScreen(val companionId: Int) : TripListUiEvent
 }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListUiEvent.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListUiEvent.kt
@@ -13,6 +13,6 @@ sealed interface TripListUiEvent {
         val characterId: String,
     ) : TripListUiEvent
     data class NavigateToKakaoOpenChat(val openChatUrl: String) : TripListUiEvent
-    data class NavigateToReviewScreen(val companionId: Long, val title: String, val date: String) : TripListUiEvent
+    data class NavigateToCharacterDescription(val characterId: String, val tag1: String, val tag2: String, val tag3: String) : TripListUiEvent
     data class NavigateToDetailScreen(val companionId: Long) : TripListUiEvent
 }

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListViewModel.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListViewModel.kt
@@ -56,10 +56,12 @@ class TripListViewModel @Inject constructor(
                 action.selectedKeyword,
                 action.tripStyle,
                 action.characterId,
+                action.companionId,
             )
 
             is TripListUiAction.OnMateOpenChatClicked -> navigateToKakaoOpenChat(action.openKakaoChatLink)
             is TripListUiAction.OnSelectMateClicked -> selectMate()
+            is TripListUiAction.OnTripDetailClicked -> navigateToDetailScreen(action.companionId)
         }
     }
 
@@ -113,13 +115,13 @@ class TripListViewModel @Inject constructor(
         }
     }
 
-    private fun navigateToMateList(companionId: Long, page: Int) {
+    private fun navigateToMateList(companionId: Int, page: Int) {
         viewModelScope.launch {
             _uiEvent.send(TripListUiEvent.NavigateToMateList(companionId = companionId, page = page))
         }
     }
 
-    private fun navigateToMateOpenChat(openChatLink: String, selectedKeyword: List<String>, tripStyle: String, characterId: String) {
+    private fun navigateToMateOpenChat(openChatLink: String, selectedKeyword: List<String>, tripStyle: String, characterId: String, companionId: Int) {
         viewModelScope.launch {
             val keyword1 = selectedKeyword.getOrNull(0) ?: ""
             val keyword2 = selectedKeyword.getOrNull(1) ?: ""
@@ -127,6 +129,7 @@ class TripListViewModel @Inject constructor(
 
             _uiEvent.send(
                 TripListUiEvent.NavigateToMateOpenChat(
+                    companionId = companionId,
                     openChatLink = openChatLink,
                     selectedKeyword1 = keyword1,
                     selectedKeyword2 = keyword2,
@@ -135,6 +138,12 @@ class TripListViewModel @Inject constructor(
                     characterId = characterId,
                 ),
             )
+        }
+    }
+
+    private fun navigateToDetailScreen(companionId: Int) {
+        viewModelScope.launch {
+            _uiEvent.send(TripListUiEvent.NavigateToDetailScreen(companionId))
         }
     }
 

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListViewModel.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListViewModel.kt
@@ -62,6 +62,12 @@ class TripListViewModel @Inject constructor(
             is TripListUiAction.OnMateOpenChatClicked -> navigateToKakaoOpenChat(action.openKakaoChatLink)
             is TripListUiAction.OnSelectMateClicked -> selectMate()
             is TripListUiAction.OnTripDetailClicked -> navigateToDetailScreen(action.companionId)
+            is TripListUiAction.OnCharacterDescriptionClicked -> navigateToCharacterDescription(
+                action.characterId,
+                action.tag1,
+                action.tag2,
+                action.tag3,
+            )
         }
     }
 
@@ -150,6 +156,12 @@ class TripListViewModel @Inject constructor(
     private fun navigateToDetailScreen(companionId: Long) {
         viewModelScope.launch {
             _uiEvent.send(TripListUiEvent.NavigateToDetailScreen(companionId))
+        }
+    }
+
+    private fun navigateToCharacterDescription(characterId: String, tag1: String, tag2: String, tag3: String) {
+        viewModelScope.launch {
+            _uiEvent.send(TripListUiEvent.NavigateToCharacterDescription(characterId, tag1, tag2, tag3))
         }
     }
 

--- a/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListViewModel.kt
+++ b/feature/trip-list/src/main/kotlin/com/tripmate/android/feature/trip_list/viewmodel/TripListViewModel.kt
@@ -115,13 +115,19 @@ class TripListViewModel @Inject constructor(
         }
     }
 
-    private fun navigateToMateList(companionId: Int, page: Int) {
+    private fun navigateToMateList(companionId: Long, page: Int) {
         viewModelScope.launch {
             _uiEvent.send(TripListUiEvent.NavigateToMateList(companionId = companionId, page = page))
         }
     }
 
-    private fun navigateToMateOpenChat(openChatLink: String, selectedKeyword: List<String>, tripStyle: String, characterId: String, companionId: Int) {
+    private fun navigateToMateOpenChat(
+        openChatLink: String,
+        selectedKeyword: List<String>,
+        tripStyle: String,
+        characterId: String,
+        companionId: Long,
+    ) {
         viewModelScope.launch {
             val keyword1 = selectedKeyword.getOrNull(0) ?: ""
             val keyword2 = selectedKeyword.getOrNull(1) ?: ""
@@ -141,7 +147,7 @@ class TripListViewModel @Inject constructor(
         }
     }
 
-    private fun navigateToDetailScreen(companionId: Int) {
+    private fun navigateToDetailScreen(companionId: Long) {
         viewModelScope.launch {
             _uiEvent.send(TripListUiEvent.NavigateToDetailScreen(companionId))
         }

--- a/feature/trip-list/src/main/res/values/strings.xml
+++ b/feature/trip-list/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="my_trip_character_info">내 여행 캐릭터 정보</string>
     <string name="character_type_intro">캐릭터 유형에 대한 소개</string>
     <string name="trip_style_intro">여행 스타일 소개</string>
+    <string name="navigate_to_trip_detail">동행 모집글 보러가기</string>
     <string name="navigate_to_mate_open_chat">동행 톡방 바로가기</string>
     <string name="mate_organizer_type">모임장의 유형은</string>
     <string name="applicant_list">신청자 목록</string>

--- a/feature/trip-list/src/main/res/values/strings.xml
+++ b/feature/trip-list/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="navigate_to_trip_detail">동행 모집글 보러가기</string>
     <string name="navigate_to_mate_open_chat">동행 톡방 바로가기</string>
     <string name="mate_organizer_type">모임장의 유형은</string>
+    <string name="mate_applicant_type">신청자의 유형은</string>
     <string name="applicant_list">신청자 목록</string>
     <string name="select_mate">동행인을 선택해주세요.</string>
     <string name="who_would_you_like_to_travel_with">누구와 함께 여행가실래요?</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 minSdk = "26"
 targetSdk = "34"
 compileSdk = "34"
-versionCode = "9"
-versionName = "0.0.9"
+versionCode = "10"
+versionName = "0.0.10"
 packageName = "com.tripmate.android"
 
 android-gradle-plugin = "8.2.2"


### PR DESCRIPTION

![ezgif-3-cee766640e](https://github.com/user-attachments/assets/6a46b1cb-e59d-443f-be0c-7bd8f8acc900)

홈화면에 캐시를 적용해 api를 카테고리 바꿀때마다 이미 받은 정보가 있다면 계속 다시 호출하지 않도록 했습니다
다만 봐주셔야할게, 로딩 애니메이션이 제가볼때는 안나오는데 코드에 문제는 없어보여서 한번 확인해주시면 감사하겠습니다.

![ezgif-3-7bc02effa7](https://github.com/user-attachments/assets/7cbc6a31-4c7c-4601-a6b2-c4253918f98a)
동행 모집글 바로가기를 구현했습니다

또한 대유님께서 companionId 를 Int로 작성하신 부분을 Long으로 수정했습니다
이부분은 혹시 잘못된게 있으면 말씀해주세요
아무래도 종료된 여행관련을 오늘 다 작성하려했는데 서버가 구현이 안되어있어서.. 좀 어려울거같네요...